### PR TITLE
Fix update_buffer when output is None

### DIFF
--- a/rplugin/python/lldb_nvim/vim_buffers.py
+++ b/rplugin/python/lldb_nvim/vim_buffers.py
@@ -146,6 +146,8 @@ class VimBuffers:  # pylint: disable=too-many-instance-attributes
         success, output = self.ctrl.get_command_result(command)
         if not success and proc_stat:
             output = proc_stat
+        if output is None:
+            output = ''
         results = output.split('\n')
 
         if buf == 'breakpoints':


### PR DESCRIPTION
On macOS 10.12 running `test/run.sh` I'd sometimes encounter a failure:
```
2018-02-25 10:30:01,132 [CRITICAL @ controller.py:run:310] 20632 - Traceback (most recent call last):
  File "/Users/alshabalin/.config/nvim/plugins/lldb.nvim/rplugin/python/lldb_nvim/controller.py", line 306, in run
    ret = method(*args)
  File "/Users/alshabalin/.config/nvim/plugins/lldb.nvim/rplugin/python/lldb_nvim/session.py", line 141, in mode_setup
    self.ctrl.update_buffers()
  File "/Users/alshabalin/.config/nvim/plugins/lldb.nvim/rplugin/python/lldb_nvim/controller.py", line 145, in update_buffers
    self.buffers.update(self.target)
  File "/Users/alshabalin/.config/nvim/plugins/lldb.nvim/rplugin/python/lldb_nvim/vim_buffers.py", line 162, in update
    self.update_buffer(buf, target)
  File "/Users/alshabalin/.config/nvim/plugins/lldb.nvim/rplugin/python/lldb_nvim/vim_buffers.py", line 150, in update_buffer
    results = output.split('\n')
AttributeError: 'NoneType' object has no attribute 'split'
```
Turns out it sometimes happens after `frame variable` execution. This commands returns success but its output is `None`.

I quickfixed it by turning `None` into `''` at `update_buffer`. What do you think?